### PR TITLE
test: cover extractor safety, concurrency, and zero-valued spans

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -87,14 +87,16 @@ func WithValueExtractor[T interface {
 	comparable
 	fmt.Stringer
 }](key ...T) ContextExtractor {
+	keys := append([]T(nil), key...)
+
 	return func(ctx context.Context) []zap.Field {
-		if len(key) == 0 {
+		if len(keys) == 0 {
 			return nil
 		}
 
-		fields := make([]zap.Field, 0, len(key))
+		fields := make([]zap.Field, 0, len(keys))
 
-		for _, k := range key {
+		for _, k := range keys {
 			if val := ctx.Value(k); val != nil {
 				fields = append(fields, zap.Any(k.String(), val))
 			}

--- a/logger_test.go
+++ b/logger_test.go
@@ -3,6 +3,7 @@ package contextlogger
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -415,6 +416,140 @@ func TestContextLogger_WithMethod(t *testing.T) {
 		_, ok := fields[key.String()]
 		require.False(t, ok)
 	})
+}
+
+func TestContextLogger_CtxIsSideEffectFree(t *testing.T) {
+	logger, observed := newTestLogger()
+
+	key1 := contextKeyString("user_id")
+	key2 := contextKeyString("request_id")
+
+	cl := WithContext(logger, WithValueExtractor(key1), WithValueExtractor(key2), WithDeadlineExtractor())
+
+	deadline := time.Now().Add(time.Hour)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	ctx = context.WithValue(ctx, key1, "user-1")
+	ctx = context.WithValue(ctx, key2, "req-1")
+
+	// Snapshot extractor slice header before repeated calls.
+	extractorsBefore := cl.extractors
+	lenBefore := len(extractorsBefore)
+	baseLogger := cl.Logger()
+
+	for i := 0; i < 50; i++ {
+		observed.TakeAll()
+		cl.Ctx(ctx).Info("repeat")
+		entries := observed.TakeAll()
+		require.Len(t, entries, 1)
+		fields := entries[0].ContextMap()
+		require.Equal(t, "user-1", fields[key1.String()])
+		require.Equal(t, "req-1", fields[key2.String()])
+		require.NotNil(t, fields["context_deadline_at"])
+	}
+
+	// Receiver unchanged: same underlying logger and same extractor slice header.
+	require.Same(t, baseLogger, cl.Logger())
+	require.Equal(t, lenBefore, len(cl.extractors))
+	require.Equal(t, fmt.Sprintf("%p", extractorsBefore), fmt.Sprintf("%p", cl.extractors))
+}
+
+func TestContextLogger_CtxConcurrent(t *testing.T) {
+	logger, _ := newTestLogger()
+
+	key1 := contextKeyString("user_id")
+	key2 := contextKeyString("request_id")
+
+	cl := WithContext(logger, WithValueExtractor(key1), WithValueExtractor(key2), WithDeadlineExtractor())
+
+	deadline := time.Now().Add(time.Hour)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	ctx = context.WithValue(ctx, key1, "user-x")
+	ctx = context.WithValue(ctx, key2, "req-x")
+
+	const goroutines = 32
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				l := cl.Ctx(ctx)
+				require.NotNil(t, l)
+				// Also exercise With() which constructs a new combined slice.
+				_ = cl.With(WithValueExtractor(key1))
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+func TestContextLogger_WithMethodCombinedNonMutation(t *testing.T) {
+	logger, observed := newTestLogger()
+
+	key1 := contextKeyString("user_id")
+	key2 := contextKeyString("request_id")
+
+	parent := WithContext(logger, WithValueExtractor(key1))
+	parentLenBefore := len(parent.extractors)
+	parentFirst := parent.extractors[0]
+
+	child := parent.With(WithValueExtractor(key2))
+
+	// Parent's slice must not have been extended or mutated.
+	require.Equal(t, parentLenBefore, len(parent.extractors))
+	require.NotSame(t, &parent.extractors[0], &child.extractors[0])
+
+	// Mutating the child's extractor slice must not affect the parent.
+	child.extractors[0] = nil
+
+	observed.TakeAll()
+	ctx := context.WithValue(context.Background(), key1, "user-parent")
+	parent.Ctx(ctx).Info("parent-unchanged")
+	entries := observed.TakeAll()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	require.Equal(t, "user-parent", fields[key1.String()])
+	// Parent's first extractor must still be intact.
+	require.NotNil(t, parent.extractors[0])
+	require.Equal(t,
+		fmt.Sprintf("%p", parentFirst),
+		fmt.Sprintf("%p", parent.extractors[0]),
+	)
+}
+
+func TestContextLogger_WithValueExtractor_KeySliceCopied(t *testing.T) {
+	logger, observed := newTestLogger()
+
+	key1 := contextKeyString("user_id")
+	key2 := contextKeyString("other")
+
+	keys := []contextKeyString{key1}
+	cl := WithContext(logger, WithValueExtractor(keys...))
+
+	// Caller mutates their slice after construction; extractor must be unaffected.
+	keys[0] = key2
+
+	ctx := context.WithValue(context.Background(), key1, "user-orig")
+	ctx = context.WithValue(ctx, key2, "should-not-appear")
+
+	observed.TakeAll()
+	cl.Ctx(ctx).Info("key-slice-copied")
+	entries := observed.TakeAll()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+
+	require.Equal(t, "user-orig", fields[key1.String()])
+	_, ok := fields[key2.String()]
+	require.False(t, ok)
 }
 
 func TestContextLogger_Logger(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -437,7 +437,7 @@ func TestContextLogger_CtxIsSideEffectFree(t *testing.T) {
 	lenBefore := len(extractorsBefore)
 	baseLogger := cl.Logger()
 
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		observed.TakeAll()
 		cl.Ctx(ctx).Info("repeat")
 		entries := observed.TakeAll()
@@ -474,12 +474,12 @@ func TestContextLogger_CtxConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 
-	for g := 0; g < goroutines; g++ {
+	for range goroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			<-start
-			for i := 0; i < iterations; i++ {
+			for range iterations {
 				l := cl.Ctx(ctx)
 				require.NotNil(t, l)
 				// Also exercise With() which constructs a new combined slice.

--- a/sentry-extractor/sentry_test.go
+++ b/sentry-extractor/sentry_test.go
@@ -223,7 +223,7 @@ func TestSentryExtractor_ZeroValuedSpan(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, sentry.SpanID{}.String(), spanID)
 
-		require.Equal(t, "", fields[FieldSpanOp])
+		require.Empty(t, fields[FieldSpanOp])
 	})
 }
 

--- a/sentry-extractor/sentry_test.go
+++ b/sentry-extractor/sentry_test.go
@@ -201,6 +201,32 @@ func TestSentryExtractor_CombinedWithOtherExtractors(t *testing.T) {
 	})
 }
 
+func TestSentryExtractor_ZeroValuedSpan(t *testing.T) {
+	_ = setUpSentry(t)
+	logger, observed := newTestLogger()
+	cl := ctxLogger.WithContext(logger, With())
+
+	t.Run("zeroed span IDs do not panic and produce zero strings", func(t *testing.T) {
+		observed.TakeAll()
+		span := sentry.StartSpan(context.Background(), "")
+		span.TraceID = sentry.TraceID{}
+		span.SpanID = sentry.SpanID{}
+		defer span.Finish()
+
+		fields := logAndAssert(t, span.Context(), observed, cl, "zero-ids")
+
+		traceID, ok := fields[FieldTraceID].(string)
+		require.True(t, ok)
+		require.Equal(t, sentry.TraceID{}.String(), traceID)
+
+		spanID, ok := fields[FieldSpanID].(string)
+		require.True(t, ok)
+		require.Equal(t, sentry.SpanID{}.String(), spanID)
+
+		require.Equal(t, "", fields[FieldSpanOp])
+	})
+}
+
 func TestSentryExtractor_SpanStatus(t *testing.T) {
 	_ = setUpSentry(t)
 	logger, observed := newTestLogger()


### PR DESCRIPTION
## Summary

Closes the test-coverage gaps surfaced in a code review of the context-logger package and hardens `WithValueExtractor` against caller-side slice mutation.

## Changes

### Source
- **`logger.go`** — `WithValueExtractor` now copies the variadic `key` slice into a closure-captured local. Previously, calling `WithValueExtractor(keys...)` shared the caller's underlying array, so mutating `keys` after construction could silently change extraction behavior. This mirrors the extractor-slice copy already performed by `New`.

### Tests
- **`TestContextLogger_CtxIsSideEffectFree`** — 50 repeated `Ctx(ctx)` calls; asserts the underlying logger and extractor slice header are unchanged afterward.
- **`TestContextLogger_CtxConcurrent`** — 32 goroutines × 200 iterations calling `Ctx` and `With` concurrently; documents race-free use under `-race`.
- **`TestContextLogger_WithMethodCombinedNonMutation`** — exercises the previously untested `combined` branch in `With()` (parent already has extractors) and verifies mutating the child's slice does not affect the parent.
- **`TestContextLogger_WithValueExtractor_KeySliceCopied`** — pins the new copy behavior: mutating the caller's key slice after construction must not change extracted fields.
- **`TestSentryExtractor_ZeroValuedSpan`** — forces a span's `TraceID`/`SpanID` to zero and `Op` to empty, asserts the extractor produces canonical zero strings without panicking. Pins the upstream `sentry-go` `.String()` contract the extractor relies on.

The otel extractor already had equivalent invalid-span-context coverage (`TestOtelExtractor_InvalidSpanContext`), so no changes there.

## Test plan

- [x] `go test -race ./...` in root module — 39 passed
- [x] `go test -race ./...` in `otel-extractor/` — 13 passed
- [x] `go test -race ./...` in `sentry-extractor/` — 15 passed
- [x] No public-API change; only `WithValueExtractor` internal closure capture changed (no signature/behavior change for non-pathological callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)