### PR TITLE
feat(logger): add context_cause field to deadline extractor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 - `With(extractors...)` returns a new `ContextLogger` when adding extractors; it must not mutate the original extractor slice.
 - `WithValueExtractor` accepts comparable `fmt.Stringer` keys and emits fields with `zap.Any(k.String(), val)` only when `ctx.Value(k)` is non-nil.
 - `WithContextCarrier` intentionally uses `zapcore.SkipType`; standard zap encoders will not emit the carrier field.
-- `WithDeadlineExtractor` only emits fields when the context has a deadline, and adds `context_error` only when `ctx.Err()` is non-nil.
+- `WithDeadlineExtractor` only emits fields when the context has a deadline, adds `context_error` only when `ctx.Err()` is non-nil, and adds `context_cause` only when `context.Cause(ctx)` differs from `ctx.Err()` (strict `!=`, not `errors.Is` — wrapped causes must still be emitted; guarded by `//nolint:errorlint`).
 
 ## Testing Patterns
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ctxLogger.Ctx(ctx).Info("request handled")
 ## Built-in extractors
 
 - **`WithValueExtractor(keys...)`** adds non-nil context values with `zap.Any`.
-- **`WithDeadlineExtractor()`** adds `context_deadline_at` and `context_time_left` when a deadline exists. It also adds `context_error` after cancellation or deadline expiry.
+- **`WithDeadlineExtractor()`** adds `context_deadline_at` and `context_time_left` when a deadline exists. It also adds `context_error` after cancellation or deadline expiry, and `context_cause` when the context was canceled with a distinct cause (see `context.WithCancelCause`).
 - **`WithContextCarrier(fieldName)`** passes the raw context to a custom Zap core or encoder. It uses `zapcore.SkipType`, so standard encoders do not emit it.
 
 ## Trace correlation

--- a/logger.go
+++ b/logger.go
@@ -16,6 +16,7 @@ const (
 	FieldContextDeadlineAt = "context_deadline_at"
 	FieldContextTimeLeft   = "context_time_left"
 	FieldContextError      = "context_error"
+	FieldContextCause      = "context_cause"
 )
 
 type ContextLogger struct {
@@ -122,6 +123,10 @@ func WithContextCarrier(fieldName string) ContextExtractor {
 	}
 }
 
+// WithDeadlineExtractor adds context_deadline_at and context_time_left when the context
+// has a deadline. After cancellation or deadline expiry it adds context_error, and
+// context_cause when the cancellation cause (see context.WithCancelCause) differs from
+// the context error.
 func WithDeadlineExtractor() ContextExtractor {
 	return func(ctx context.Context) []zap.Field {
 		deadline, ok := ctx.Deadline()
@@ -129,15 +134,21 @@ func WithDeadlineExtractor() ContextExtractor {
 			return nil
 		}
 
-		fields := make([]zap.Field, 0, 3)
+		fields := make([]zap.Field, 0, 4)
 
 		fields = append(fields,
 			zap.Time(FieldContextDeadlineAt, deadline),
 			zap.Duration(FieldContextTimeLeft, time.Until(deadline)),
 		)
 
-		if ctx.Err() != nil {
-			fields = append(fields, zap.String(FieldContextError, ctx.Err().Error()))
+		if err := ctx.Err(); err != nil {
+			fields = append(fields, zap.String(FieldContextError, err.Error()))
+
+			//nolint:errorlint // exact equality is intentional: Cause returns ctx.Err() verbatim
+			// when no cause was set, while errors.Is would also drop wrapped causes.
+			if cause := context.Cause(ctx); cause != err {
+				fields = append(fields, zap.String(FieldContextCause, cause.Error()))
+			}
 		}
 
 		return fields

--- a/logger_test.go
+++ b/logger_test.go
@@ -271,6 +271,41 @@ func TestContextLogger_WithDeadlineExtractor(t *testing.T) {
 		require.WithinDuration(t, deadline, deadlineAt, 50*time.Millisecond)
 
 		require.Equal(t, "context canceled", fields["context_error"])
+
+		_, ok = fields["context_cause"]
+		require.False(t, ok, "plain cancel must not emit context_cause")
+	})
+
+	t.Run("canceled with cause", func(t *testing.T) {
+		observed.TakeAll()
+		deadline := time.Now().Add(2 * time.Second)
+		deadlineCtx, deadlineCancel := context.WithDeadline(context.Background(), deadline)
+		defer deadlineCancel()
+		ctx, cancel := context.WithCancelCause(deadlineCtx)
+		defer cancel(nil)
+		cancel(fmt.Errorf("connection reset by peer"))
+
+		cl := WithContext(logger, WithDeadlineExtractor())
+		fields := logAndAssert(t, ctx, observed, cl, "canceled-with-cause")
+
+		require.Equal(t, "context canceled", fields["context_error"])
+		require.Equal(t, "connection reset by peer", fields["context_cause"])
+	})
+
+	t.Run("canceled with wrapped cause", func(t *testing.T) {
+		observed.TakeAll()
+		deadline := time.Now().Add(2 * time.Second)
+		deadlineCtx, deadlineCancel := context.WithDeadline(context.Background(), deadline)
+		defer deadlineCancel()
+		ctx, cancel := context.WithCancelCause(deadlineCtx)
+		defer cancel(nil)
+		cancel(fmt.Errorf("shutdown: %w", context.Canceled))
+
+		cl := WithContext(logger, WithDeadlineExtractor())
+		fields := logAndAssert(t, ctx, observed, cl, "wrapped-cause")
+
+		require.Equal(t, "context canceled", fields["context_error"])
+		require.Equal(t, "shutdown: context canceled", fields["context_cause"])
 	})
 }
 

--- a/skills/golang-context-logger/SKILL.md
+++ b/skills/golang-context-logger/SKILL.md
@@ -29,7 +29,7 @@ This package keeps the normal zap API: call `ctxLogger.Ctx(ctx)` to get a `*zap.
 Use this skill when the task involves:
 
 - Adding request IDs, user IDs, tenant IDs, correlation IDs, or similar request-scoped values to zap logs.
-- Logging context deadline metadata such as `context_deadline_at`, `context_time_left`, and `context_error`.
+- Logging context deadline metadata such as `context_deadline_at`, `context_time_left`, `context_error`, and `context_cause`.
 - Adding OpenTelemetry `trace_id` and `span_id` fields to logs.
 - Adding Sentry `trace_id`, `span_id`, `span_status`, and `span_op` fields to logs.
 - Writing a custom `ContextExtractor`.
@@ -123,6 +123,7 @@ Fields:
 - `context_deadline_at`: the deadline as `time.Time`.
 - `context_time_left`: duration until the deadline.
 - `context_error`: present only when `ctx.Err()` is non-nil.
+- `context_cause`: present only when the context was canceled with a distinct cause via `context.WithCancelCause`.
 
 No fields are emitted when the context has no deadline.
 


### PR DESCRIPTION
- emit context_cause when context.Cause(ctx) differs from ctx.Err()
- strict != comparison so wrapped causes are still emitted