### PR TITLE
perf(logger): fast-path Ctx without extractors; add godoc examples

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,50 @@
+package contextlogger_test
+
+import (
+	"context"
+	"os"
+
+	ctxlog "github.com/adlandh/context-logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type exampleContextKey string
+
+func (k exampleContextKey) String() string { return string(k) }
+
+const exampleRequestIDKey = exampleContextKey("request_id")
+
+// newExampleLogger returns a JSON logger writing to stdout so example output
+// can be verified with // Output: comments.
+func newExampleLogger() *zap.Logger {
+	encoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{MessageKey: "msg"})
+	return zap.New(zapcore.NewCore(encoder, zapcore.AddSync(os.Stdout), zapcore.InfoLevel))
+}
+
+func ExampleNew() {
+	logger := newExampleLogger()
+	ctxLogger := ctxlog.New(logger, ctxlog.WithValueExtractor(exampleRequestIDKey))
+
+	ctx := context.WithValue(context.Background(), exampleRequestIDKey, "req-7f3")
+	ctxLogger.Ctx(ctx).Info("request completed")
+
+	// Output:
+	// {"msg":"request completed","request_id":"req-7f3"}
+}
+
+func ExampleContextLogger_Ctx() {
+	logger := newExampleLogger()
+	ctxLogger := ctxlog.WithContext(logger, ctxlog.WithValueExtractor(exampleRequestIDKey))
+
+	// Add an extractor for a narrower scope; the base logger is unchanged.
+	userIDKey := exampleContextKey("user_id")
+	auditLogger := ctxLogger.With(ctxlog.WithValueExtractor(userIDKey))
+
+	ctx := context.WithValue(context.Background(), exampleRequestIDKey, "req-7f3")
+	ctx = context.WithValue(ctx, userIDKey, "user-123")
+	auditLogger.Ctx(ctx).Info("audit event recorded")
+
+	// Output:
+	// {"msg":"audit event recorded","request_id":"req-7f3","user_id":"user-123"}
+}

--- a/logger.go
+++ b/logger.go
@@ -44,10 +44,6 @@ func WithContext(logger *zap.Logger, extractors ...ContextExtractor) *ContextLog
 }
 
 func (c *ContextLogger) Ctx(ctx context.Context) *zap.Logger {
-	if len(c.extractors) == 0 {
-		return c.logger
-	}
-
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/logger.go
+++ b/logger.go
@@ -44,6 +44,10 @@ func WithContext(logger *zap.Logger, extractors ...ContextExtractor) *ContextLog
 }
 
 func (c *ContextLogger) Ctx(ctx context.Context) *zap.Logger {
+	if len(c.extractors) == 0 {
+		return c.logger
+	}
+
 	if ctx == nil {
 		ctx = context.Background()
 	}


### PR DESCRIPTION
- return c.logger directly when no extractors are configured (0 allocs)
- ExampleNew and ExampleContextLogger_Ctx run as tests and render on pkg.go.dev